### PR TITLE
Use clj-http to avoid oom on large object download

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,9 @@
-{:deps {com.monkeyprojects/oci-common {:mvn/version "0.1.1"}
+{:deps {com.monkeyprojects/oci-common {:mvn/version "0.1.2-SNAPSHOT"}
+        clj-http/clj-http {:mvn/version "3.12.3"}
         http-kit/http-kit {:mvn/version "2.6.0"}
         buddy/buddy-sign {:mvn/version "3.5.346"}
-        manifold/manifold {:mvn/version "0.4.1"}}
+        manifold/manifold {:mvn/version "0.4.2"}
+        medley/medley {:mvn/version "1.4.0"}}
  
  :aliases
  {:dev
@@ -12,7 +14,7 @@
                 org.slf4j/slf4j-api {:mvn/version "2.0.7"}
                 ch.qos.logback/logback-classic {:mvn/version "1.4.8"}
                 yogthos/config {:mvn/version "1.2.0"}
-                http-kit.fake/http-kit.fake {:mvn/version "0.2.1"}
+                clj-http-fake/clj-http-fake {:mvn/version "1.0.4"}
                 com.github.oliyh/martian-test {:mvn/version "0.1.24"}}
    :extra-paths ["test" "dev-resources"]
    :exec-fn monkey.test/all}

--- a/dev-resources/logback-test.xml
+++ b/dev-resources/logback-test.xml
@@ -6,10 +6,10 @@
     </encoder>
   </appender>
   
+  <logger name="user" level="DEBUG"/>
   <logger name="monkey.oci" level="DEBUG"/>
   <logger name="monkey.oci.sign" level="INFO"/>
   <logger name="com.oracle" level="TRACE"/>
-  <logger name="org.httpkit" level="DEBUG"/>
   
   <root level="WARN">
     <appender-ref ref="CONSOLE" />

--- a/env/dev/user.clj
+++ b/env/dev/user.clj
@@ -1,6 +1,8 @@
 (ns user
-  (:require [clojure.tools.logging :as log]
+  (:require [clojure.java.io :as io]
+            [clojure.tools.logging :as log]
             [config.core :refer [env]]
+            [manifold.deferred :as md]
             [monkey.oci.os
              [core :as c]
              [martian :as m]]
@@ -24,6 +26,11 @@
 (defn get-object [obj]
   (log/info "Retrieving object" obj)
   @(c/get-object ctx {:ns @bucket-ns :bucket-name bucket-name :object-name obj}))
+
+(defn download-object [obj dest]
+  (md/chain
+   (c/get-object ctx {:ns @bucket-ns :bucket-name bucket-name :object-name obj})
+   #(io/copy % dest :buffer-size 0x100000)))
 
 (defn put-object [obj contents]
   (log/info "Putting object" obj)


### PR DESCRIPTION
Replacing httpkit with clj-http as the http client because httpkit is unable to process a request without buffering it into memory first.  This is problematic when downloading large files.  clj-http can do this better.